### PR TITLE
Handle a new class of labels called 'warnings'

### DIFF
--- a/wikiparsec.cabal
+++ b/wikiparsec.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                wikiparsec
-version:             1.2.0
+version:             1.3.0
 synopsis:            An LL parser for extracting information from Wiki text, particularly Wiktionary.
 -- description:
 homepage:            http://github.com/LuminosoInsight/wikiparsec


### PR DESCRIPTION
This change to wikiparsec helps us avoid output that detracts from ConceptNet, perhaps because it involves obsolete forms of words, or because it outputs offensive definitions that are removed from the Wiktionary context saying that they're offensive.

Definitions that are labeled with one of several Wiktionary templates (such as "archaic" or "ethnic slur") will only output a single fact about that "warning label", instead of extracting facts from the definition.